### PR TITLE
ENH: Make stirling2 support pure python when overflow

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -795,6 +795,8 @@ from ._spherical_bessel import (
     spherical_kn
 )
 
+from ._stirling2 import stirling2
+
 # Deprecated namespaces, to be removed in v2.0.0
 from . import add_newdocs, basic, orthogonal, specfun, sf_error, spfun_stats
 

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -13942,44 +13942,15 @@ add_newdoc("ndtri_exp",
     """)
 
 
-add_newdoc("stirling2",
-    r"""
-    stirling2(n, k)
+add_newdoc("_stirling2",
+    """
+    Internal function, use `stirling2` instead.
+    """
+)
 
-    Stirling number of the second kind. Counts the number of non-empty subsets
-    of `n` set items that can be made with `k` non-empty subsets. Both `n` and
-    `k` should be non-negative integers, Negative integers for either `n` or
-    `k` cause the function to return `0`. If there is an error allocating the
-    array for the computation a `-1` is returned and if an overflow occurs
-    during the computation a `-2` is returned.
+add_newdoc("_stirling2_inexact",
+    """
+    Internal function, use `stirling2` instead.
+    """
+)
 
-    Parameters
-    ----------
-    n : array_like
-        The number of items in the set
-    k : array_like
-        The number of non-empty subsets to be made out of the n elements
-
-    Returns
-    -------
-    scalar or ndarray
-        The number of ways to make k non-empty subsets out of n elements
-
-    Examples
-    --------
-    >>> import scipy.special as sc
-    >>> sc.stirling2(0,0)
-    1
-    >>> sc.stirling2(3,0)
-    0
-    >>> sc.stirling2(4,2)
-    7
-    >>> sc.stirling2(4,3)
-    6
-    >>> sc.stirling2(26,10)
-    -2
-
-    See Also
-    --------
-    comb, factorial
-    """)

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -13941,16 +13941,8 @@ add_newdoc("ndtri_exp",
     log_ndtr, ndtri, ndtr
     """)
 
-
-add_newdoc("_stirling2",
+add_newdoc("_stirling2_approx",
     """
     Internal function, use `stirling2` instead.
     """
 )
-
-add_newdoc("_stirling2_inexact",
-    """
-    Internal function, use `stirling2` instead.
-    """
-)
-

--- a/scipy/special/_cephes.pxd
+++ b/scipy/special/_cephes.pxd
@@ -78,7 +78,6 @@ cdef extern from "cephes.h" nogil:
     double round(double x)
     int shichi(double x, double *si, double *ci)
     int sici(double x, double *si, double *ci)
-    long stirling2(int n, int k)
     double radian(double d, double m, double s)
     double sindg(double x)
     double sinpi(double x)

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -22,9 +22,7 @@ def stirling2(n, k, exact=True):
 
 def _stirling2_pyint(n, k):
     if k <= 0 or k > n or n < 0:
-        if n == 0:
-            return 1
-        return 0
+        return 1 if n == 0 else 0
     if k <= n - k + 1:
         current = [1]*k
         for i in range(1, n - k + 1):

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from scipy.special._ufuncs import _stirling2
+from scipy.special._ufuncs import _stirling2_inexact
+
+
+def stirling2(n, k, exact=True):
+    if exact:
+        if not (np.issubdtype(type(n), np.integer)
+                and np.issubdtype(type(k), np.integer)):
+            raise TypeError("Placeholder, need appropriate error message")
+        try:
+            output = _stirling2(n, k)
+        except TypeError:
+            output = -1
+        if output < 0:
+            return _stirling2_pyint(n, k)
+        return output
+    else:
+        return _stirling2_inexact(n, k)
+
+
+def _stirling2_pyint(n, k):
+    if k <= 0 or k > n or n < 0:
+        if n == 0:
+            return 1
+        return 0
+    if k <= n - k + 1:
+        current = [1]*k
+        for i in range(1, n - k + 1):
+            for j in range(1, k):
+                current[j] = (j+1) * current[j] + current[j-1]
+    else:
+        current = [1]*(n - k + 1)
+        for i in range(1, k):
+            for j in range(1, n - k + 1):
+                current[j] = (i+1) * current[j-1] + current[j]
+    return current[-1]

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -85,7 +85,7 @@ def _stirling2_pyint(n, k):
     if k <= 0 or k > n or n < 0:
         return 0
 
-    # DLMF 26.8.15 https://dlmf.nist.gov/26.8#E15
+    # DLMF 26.8.16 https://dlmf.nist.gov/26.8#E16
     if k == n - 1:
         return sc.comb(n, 2, exact=True)
 

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -53,12 +53,43 @@ def stirling2(n, k, exact=True):
 
 
 def _stirling2_pyint(n, k):
+    """Compute Stirling numbers of second kind with arbitrary precision ints
+
+     Computes from the bottom up using the recurrence relation
+     stirling2(n, k) = k * stirling2(n, k - 1) + stirling2(n - 1, k - 1)
+     with boundary conditions: stirling2(n, 1) = 1, stirling2(n, n) = 1.
+     The below implementation only computes the Stirling numbers necessary
+     for the final result. Arranging the Stirling numbers in a triangle
+     with stirling2(1, 1) at the top, n increasing from top to bottom and
+     k increasing from left to right, to compute stirling2(n, k) one
+     only needs to compute the values in the parallelogram with vertices at
+     (1, 1), (k, k), (k, 1), (n, k). This is illustrated in the ASCII diagram
+     below for stirling2(5, 3).
+
+     x
+     x x
+     x x x
+     o x x o
+     o o x o o
+     o o o o o o
+
+     To minimize the memory needed, if k <= n - k + 1, an array of length k
+     is allocated and the cells of the parallelogram are filled in order from
+     left to right and then top to bottom. If k > n - k + 1, an array of
+     length n - k + 1 is allocated and the cells are filled in order from top
+     to bottom and then left to right. See
+     https://github.com/scipy/scipy/pull/18103#discussion_r1130036365
+    """
+    # Check for boundary cases.
     if n == 0 and k == 0:
         return 1
     if k <= 0 or k > n or n < 0:
         return 0
+
+    # DLMF 26.8.15 https://dlmf.nist.gov/26.8#E15
     if k == n - 1:
         return sc.comb(n, 2, exact=True)
+
     if k <= n - k + 1:
         current = [1]*k
         for i in range(1, n - k + 1):

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -1,23 +1,13 @@
 import numpy as np
-
-from scipy.special._ufuncs import _stirling2
-from scipy.special._ufuncs import _stirling2_inexact
+from scipy.special._ufuncs import _stirling2_approx
 
 
 def stirling2(n, k, exact=True):
+    """Needs updated docstring."""
     if exact:
-        if not (np.issubdtype(type(n), np.integer)
-                and np.issubdtype(type(k), np.integer)):
-            raise TypeError("Placeholder, need appropriate error message")
-        try:
-            output = _stirling2(n, k)
-        except TypeError:
-            output = -1
-        if output < 0:
-            return _stirling2_pyint(n, k)
-        return output
+        return _stirling2_pyint(n, k)
     else:
-        return _stirling2_inexact(n, k)
+        return _stirling2_approx(n, k)
 
 
 def _stirling2_pyint(n, k):

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -21,8 +21,10 @@ def stirling2(n, k, exact=True):
 
 
 def _stirling2_pyint(n, k):
+    if n == 0 and k == 0:
+        return 1
     if k <= 0 or k > n or n < 0:
-        return 1 if n == 0 else 0
+        return 0
     if k <= n - k + 1:
         current = [1]*k
         for i in range(1, n - k + 1):

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -3,7 +3,45 @@ from scipy.special._ufuncs import _stirling2_approx
 
 
 def stirling2(n, k, exact=True):
-    """Needs updated docstring."""
+    """stirling2(n, k)
+
+    Stirling number of the second kind. Counts the number of non-empty subsets
+    of `n` set items that can be made with `k` non-empty subsets. Both `n` and
+    `k` should be non-negative integers, Negative integers for either `n` or
+    `k` cause the function to return `0`. If there is an error allocating the
+    array for the computation a `-1` is returned and if an overflow occurs
+    during the computation a `-2` is returned.
+
+    Parameters
+    ----------
+    n : array_like
+        The number of items in the set
+    k : array_like
+        The number of non-empty subsets to be made out of the n elements
+
+    Returns
+    -------
+    scalar or ndarray
+        The number of ways to make k non-empty subsets out of n elements
+
+    Examples
+    --------
+    >>> import scipy.special as sc
+    >>> sc.stirling2(0,0)
+    1
+    >>> sc.stirling2(3,0)
+    0
+    >>> sc.stirling2(4,2)
+    7
+    >>> sc.stirling2(4,3)
+    6
+    >>> sc.stirling2(26,10)
+    -2
+
+    See Also
+    --------
+    comb, factorial
+    """
     if exact:
         return _stirling2_pyint(n, k)
     else:

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -1,4 +1,3 @@
-import numpy as np
 import scipy.special as sc
 
 from scipy.special._ufuncs import _stirling2_approx

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -1,4 +1,6 @@
 import numpy as np
+import scipy.special as sc
+
 from scipy.special._ufuncs import _stirling2_approx
 
 
@@ -55,6 +57,8 @@ def _stirling2_pyint(n, k):
         return 1
     if k <= 0 or k > n or n < 0:
         return 0
+    if k == n - 1:
+        return sc.comb(n, 2, exact=True)
     if k <= n - k + 1:
         current = [1]*k
         for i in range(1, n - k + 1):

--- a/scipy/special/_stirling2.py
+++ b/scipy/special/_stirling2.py
@@ -8,21 +8,23 @@ def stirling2(n, k, exact=True):
     Stirling number of the second kind. Counts the number of non-empty subsets
     of `n` set items that can be made with `k` non-empty subsets. Both `n` and
     `k` should be non-negative integers, Negative integers for either `n` or
-    `k` cause the function to return `0`. If there is an error allocating the
-    array for the computation a `-1` is returned and if an overflow occurs
-    during the computation a `-2` is returned.
+    `k` cause the function to return `0`.
 
     Parameters
     ----------
-    n : array_like
+    n : int, array_like
         The number of items in the set
-    k : array_like
+    k : int, array_like
         The number of non-empty subsets to be made out of the n elements
 
     Returns
     -------
-    scalar or ndarray
+    int, scalar or ndarray
         The number of ways to make k non-empty subsets out of n elements
+
+    Notes
+    -----
+    - Array arguments accepted only for exact=False case.
 
     Examples
     --------
@@ -36,7 +38,7 @@ def stirling2(n, k, exact=True):
     >>> sc.stirling2(4,3)
     6
     >>> sc.stirling2(26,10)
-    -2
+    13199555372846848005
 
     See Also
     --------

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -109,8 +109,7 @@ extern double round(double x);
 extern int shichi(double x, double *si, double *ci);
 extern int sici(double x, double *si, double *ci);
 
-extern long int stirling2(int n, int k);
-extern double stirling2_inexact(long int n, long int k);
+extern double stirling2_approx(long int n, long int k);
 
 extern double radian(double d, double m, double s);
 extern double sindg(double x);

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -109,7 +109,8 @@ extern double round(double x);
 extern int shichi(double x, double *si, double *ci);
 extern int sici(double x, double *si, double *ci);
 
-long int stirling2(int n, int k);
+extern long int stirling2(int n, int k);
+extern double stirling2_inexact(long int n, long int k);
 
 extern double radian(double d, double m, double s);
 extern double sindg(double x);

--- a/scipy/special/cephes/cephes_names.h
+++ b/scipy/special/cephes/cephes_names.h
@@ -111,5 +111,6 @@
 #define kolmogci cephes_kolmogci
 #define owens_t cephes_owens_t
 #define stirling2 cephes_stirling2
+#define stirling2_inexact cephes_stirling2_inexact
 
 #endif

--- a/scipy/special/cephes/cephes_names.h
+++ b/scipy/special/cephes/cephes_names.h
@@ -110,7 +110,6 @@
 #define kolmogc cephes_kolmogc
 #define kolmogci cephes_kolmogci
 #define owens_t cephes_owens_t
-#define stirling2 cephes_stirling2
-#define stirling2_inexact cephes_stirling2_inexact
+#define stirling2_approx cephes_stirling2_approx
 
 #endif

--- a/scipy/special/cephes/stirling.c
+++ b/scipy/special/cephes/stirling.c
@@ -32,11 +32,11 @@ static uint64_t stirling2(long n, long k){
     /* Don't need to check for edge cases. This function is only meant to be
      * called from stirling2_approx which checks for these cases.
      */
-    int arraySize = k <= n - k + 1 ? k : n - k + 1;
+    unsigned int arraySize = k <= n - k + 1 ? k : n - k + 1;
     uint64_t *curr = malloc(arraySize * sizeof(uint64_t));
     if (!curr) {
         sf_error("stirling2", SF_ERROR_NO_RESULT, "failed to allocate memory");
-        return -2;
+        return 0;
     }
     /* Computes from the bottom up using the recurrence relation
      * stirling2(n, k) = k * stirling2(n, k - 1) + stirling2(n - 1, k - 1)
@@ -63,44 +63,44 @@ static uint64_t stirling2(long n, long k){
      * to bottom and then left to right. See
      * https://github.com/scipy/scipy/pull/18103#discussion_r1130036365
      */
-    for (int i = 0; i < arraySize; i++){
+    for (unsigned int i = 0; i < arraySize; i++){
         curr[i] = 1;
     }
     uint64_t tmp;
     if (k <= n - k + 1) {
-        for (int i = 1; i < n - k + 1; i++){
-            for (int j = 1; j < k; j++){
+        for (unsigned int i = 1; i < n - k + 1; i++){
+            for (unsigned int j = 1; j < k; j++){
 	      if (curr[j] > UINT64_MAX / (j + 1)) {
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT,
 		         "integer overflow has occured");
-		return -1;
+		return 0;
 	      }
 	      tmp = curr[j] * (j + 1);
 	      if (tmp > UINT64_MAX - curr[j - 1]) {
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT,
 		         "integer overflow has occured");
-		return -1;
+		return 0;
 	      }
 	      curr[j] = tmp + curr[j - 1];
             }
         }
     } else {
-        for (int i = 1; i < k; i++){
-            for (int j = 1; j < n - k + 1; j++){
+        for (unsigned int i = 1; i < k; i++){
+            for (unsigned int j = 1; j < n - k + 1; j++){
 	      if (curr[j - 1] > UINT64_MAX / (i + 1)){
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT,
 		         "integer overflow has occured");
-		return -1;
+		return 0;
 	      }
 	      tmp = curr[j - 1] * (i + 1);
 	      if (tmp > UINT64_MAX - curr[j]) {
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT, 
 		         "integer overflow has occured");
-		return -1;
+		return 0;
 	      }
 	      curr[j] = tmp + curr[j];
           }

--- a/scipy/special/cephes/stirling.c
+++ b/scipy/special/cephes/stirling.c
@@ -111,3 +111,29 @@ long stirling2(int n, int k){
     free(curr);
     return output;
 }
+
+
+double stirling2_inexact(long n, long k) {
+    long result;
+    if (n == 0 && k == 0){
+        return 1.0;
+    }
+    if (k <= 0 || k > n || n <= 0){
+        return 0.0;
+    }
+    if (n > INT_MAX || k > INT_MAX) {
+      result = -1;
+    }
+    else {
+      result = stirling2(n, k);
+    }
+    if (result < 0) {
+      /* Placeholder. This will use asymptotic approximation from
+       * Temme, N. M., (1993), Asymptotic Estimates of Stirling Numbers,
+       * Studies in Applied Mathematics, 89, doi: 10.1002/sapm1993893233.
+       */
+      sf_error("stirling2", SF_ERROR_NO_RESULT, NULL);
+      return NAN;
+    }
+    return (double)result;
+}

--- a/scipy/special/cephes/stirling.c
+++ b/scipy/special/cephes/stirling.c
@@ -113,7 +113,7 @@ long stirling2(int n, int k){
 }
 
 
-double stirling2_inexact(long n, long k) {
+double stirling2_approx(long n, long k) {
     long result;
     if (n == 0 && k == 0){
         return 1.0;

--- a/scipy/special/cephes/stirling.c
+++ b/scipy/special/cephes/stirling.c
@@ -28,11 +28,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-static uint64_t stirling2(long n, long k){
+static uint64_t stirling2(uint64_t n, uint64_t k){
     /* Don't need to check for edge cases. This function is only meant to be
      * called from stirling2_approx which checks for these cases.
      */
-    unsigned int arraySize = k <= n - k + 1 ? k : n - k + 1;
+    uint64_t arraySize = k <= n - k + 1 ? k : n - k + 1;
     uint64_t *curr = malloc(arraySize * sizeof(uint64_t));
     if (!curr) {
         sf_error("stirling2", SF_ERROR_NO_RESULT, "failed to allocate memory");
@@ -63,13 +63,13 @@ static uint64_t stirling2(long n, long k){
      * to bottom and then left to right. See
      * https://github.com/scipy/scipy/pull/18103#discussion_r1130036365
      */
-    for (unsigned int i = 0; i < arraySize; i++){
+    for (uint64_t i = 0; i < arraySize; i++){
         curr[i] = 1;
     }
     uint64_t tmp;
     if (k <= n - k + 1) {
-        for (unsigned int i = 1; i < n - k + 1; i++){
-            for (unsigned int j = 1; j < k; j++){
+        for (uint64_t i = 1; i < n - k + 1; i++){
+            for (uint64_t j = 1; j < k; j++){
 	      if (curr[j] > UINT64_MAX / (j + 1)) {
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT,
@@ -87,8 +87,8 @@ static uint64_t stirling2(long n, long k){
             }
         }
     } else {
-        for (unsigned int i = 1; i < k; i++){
-            for (unsigned int j = 1; j < n - k + 1; j++){
+        for (uint64_t i = 1; i < k; i++){
+            for (uint64_t j = 1; j < n - k + 1; j++){
 	      if (curr[j - 1] > UINT64_MAX / (i + 1)){
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT,

--- a/scipy/special/cephes/stirling.c
+++ b/scipy/special/cephes/stirling.c
@@ -33,7 +33,7 @@ static uint64_t stirling2(long n, long k){
      * called from stirling2_approx which checks for these cases.
      */
     int arraySize = k <= n - k + 1 ? k : n - k + 1;
-    uint64_t *curr = malloc(arraySize * sizeof(int64_t));
+    uint64_t *curr = malloc(arraySize * sizeof(uint64_t));
     if (!curr) {
         sf_error("stirling2", SF_ERROR_NO_RESULT, "failed to allocate memory");
         return -2;

--- a/scipy/special/cephes/stirling.c
+++ b/scipy/special/cephes/stirling.c
@@ -1,4 +1,4 @@
-/* c implementation of Stirling numbers of the second kind */
+/* c implementation to approximate Stirling numbers of the second kind */
 
 /*
  *
@@ -14,8 +14,10 @@
  *  to be partitioned and k is the number of non-empty subsets.
  *  The values for n < 0 or k < 0 are interpreted as 0. If you
  *
- * ACCURACY: The method returns an unsigned integer type and
- *  the size of the type 32 bits.
+ * ACCURACY: Returns correctly rounded result to double precision
+ * if result does not overflow an unsigned 64 bit int. Currently
+ * returns nan if result overflows usigned 64 bit int, with plan
+ * to eventually use an asymptotic approximation in these cases.
  *
  *
  * NOTE: this file is *NOT* part of the ceph distribution and was

--- a/scipy/special/cephes/stirling.c
+++ b/scipy/special/cephes/stirling.c
@@ -23,21 +23,18 @@
  *  https://github.com/scipy/scipy/issues/17890
  */
 #include "mconf.h"
-#include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 
-long stirling2(int n, int k){
-    if (n == 0 && k == 0){
-        return 1L;
-    }
-    if (k <= 0 || k > n || n <= 0){
-        return 0L;
-    }
+static uint64_t stirling2(long n, long k){
+    /* Don't need to check for edge cases. This function is only meant to be
+     * called from stirling2_approx which checks for these cases.
+     */
     int arraySize = k <= n - k + 1 ? k : n - k + 1;
-    long *curr = malloc(arraySize * sizeof(long));
+    uint64_t *curr = malloc(arraySize * sizeof(int64_t));
     if (!curr) {
         sf_error("stirling2", SF_ERROR_NO_RESULT, "failed to allocate memory");
-        return -2L;
+        return -2;
     }
     /* Computes from the bottom up using the recurrence relation
      * stirling2(n, k) = k * stirling2(n, k - 1) + stirling2(n - 1, k - 1)
@@ -65,24 +62,24 @@ long stirling2(int n, int k){
      * https://github.com/scipy/scipy/pull/18103#discussion_r1130036365
      */
     for (int i = 0; i < arraySize; i++){
-        curr[i] = 1L;
+        curr[i] = 1;
     }
-    long tmp;
+    uint64_t tmp;
     if (k <= n - k + 1) {
         for (int i = 1; i < n - k + 1; i++){
             for (int j = 1; j < k; j++){
-	      if (curr[j] > LONG_MAX / (j + 1)) {
+	      if (curr[j] > UINT64_MAX / (j + 1)) {
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT,
 		         "integer overflow has occured");
-		return -1L;
+		return -1;
 	      }
 	      tmp = curr[j] * (j + 1);
-	      if (tmp > LONG_MAX - curr[j - 1]) {
+	      if (tmp > UINT64_MAX - curr[j - 1]) {
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT,
 		         "integer overflow has occured");
-		return -1L;
+		return -1;
 	      }
 	      curr[j] = tmp + curr[j - 1];
             }
@@ -90,44 +87,41 @@ long stirling2(int n, int k){
     } else {
         for (int i = 1; i < k; i++){
             for (int j = 1; j < n - k + 1; j++){
-	      if (curr[j - 1] > LONG_MAX / (i + 1)){
+	      if (curr[j - 1] > UINT64_MAX / (i + 1)){
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT,
 		         "integer overflow has occured");
-		return -1L;
+		return -1;
 	      }
 	      tmp = curr[j - 1] * (i + 1);
-	      if (tmp > LONG_MAX - curr[j]) {
+	      if (tmp > UINT64_MAX - curr[j]) {
 		free(curr);
 		sf_error("stirling2", SF_ERROR_NO_RESULT, 
 		         "integer overflow has occured");
-		return -1L;
+		return -1;
 	      }
 	      curr[j] = tmp + curr[j];
           }
       }
   }
-    long output = curr[arraySize - 1];
+    uint64_t output = curr[arraySize - 1];
     free(curr);
     return output;
 }
 
 
 double stirling2_approx(long n, long k) {
-    long result;
+    uint64_t result;
     if (n == 0 && k == 0){
         return 1.0;
     }
     if (k <= 0 || k > n || n <= 0){
         return 0.0;
     }
-    if (n > INT_MAX || k > INT_MAX) {
-      result = -1;
-    }
-    else {
+    else { // TODO: Add a check to detect cases where overflow is guaranteed
       result = stirling2(n, k);
     }
-    if (result < 0) {
+    if (!result) {
       /* Placeholder. This will use asymptotic approximation from
        * Temme, N. M., (1993), Asymptotic Estimates of Stirling Numbers,
        * Studies in Applied Mathematics, 89, doi: 10.1002/sapm1993893233.

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1388,9 +1388,14 @@
             "cdft2_wrap": "dd->d"
         }
     },
-    "stirling2": {
+    "_stirling2": {
         "cephes.h": {
             "stirling2": "ii->l"
+        }
+    },
+    "_stirling2_inexact": {
+        "cephes.h": {
+            "stirling2_inexact": "ll->d"
         }
     },
     "struve": {

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1388,14 +1388,9 @@
             "cdft2_wrap": "dd->d"
         }
     },
-    "_stirling2": {
+    "_stirling2_approx": {
         "cephes.h": {
-            "stirling2": "ii->l"
-        }
-    },
-    "_stirling2_inexact": {
-        "cephes.h": {
-            "stirling2_inexact": "ll->d"
+            "stirling2_approx": "ll->d"
         }
     },
     "struve": {

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -493,7 +493,8 @@ python_sources = [
   'orthogonal.py',
   'sf_error.py',
   'specfun.py',
-  'spfun_stats.py'
+  'spfun_stats.py',
+  '_stirling2.py'
 ]
 
 py3.install_sources(

--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -33,7 +33,7 @@ from ._complexstuff cimport (
 )
 
 from . cimport sf_error
-from ._cephes cimport Gamma, lgam, beta, lbeta, gammasgn, stirling2
+from ._cephes cimport Gamma, lgam, beta, lbeta, gammasgn
 from ._cephes cimport hyp2f1 as hyp2f1_wrap
 
 cdef extern from "specfun_wrappers.h":

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -284,7 +284,6 @@ PARAMS: list[tuple[Callable, Callable, tuple[str, ...], str | None]] = [
     (special.yve, cython_special.yve, ('dd', 'dD'), None),
     (special.zetac, cython_special.zetac, ('d',), None),
     (special.owens_t, cython_special.owens_t, ('dd',), None),
-    (special.stirling2, cython_special.stirling2, ('ii',), None),
 ]
 
 

--- a/scipy/special/tests/test_stirling.py
+++ b/scipy/special/tests/test_stirling.py
@@ -1,4 +1,6 @@
+import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 from math import comb
 from random import randrange
 from scipy.special import stirling2
@@ -43,13 +45,34 @@ from scipy.special import stirling2
     (6, 6, 1),
     (6, 7, 0),
 ])
-def test_triangle(n, k, expected):
-    assert stirling2(n, k) == expected
+def test_triangle_exact(n, k, expected):
+    assert stirling2(n, k, exact=True) == expected
 
 
-def test_modulus():
-    # do not need to fix seed
-    n = randrange(7, 12)
-    k = randrange(n)
+@pytest.mark.parametrize('n,expected', [
+    (0, [1]),
+    (1, [0, 1]),
+    (2, [0, 1, 1]),
+    (3, [0, 1, 3, 1]),
+    (4, [0, 1, 7, 6, 1]),
+    (5, [0, 1, 15, 25, 10, 1]),
+    (6, [0, 1, 31, 90, 65, 15, 1]),
+    (7, [0, 1, 63, 301, 350, 140, 21, 1]),
+    (8, [0, 1, 127, 966, 1701, 1050, 266, 28, 1]),
+    (9, [0, 1, 255, 3025, 7770, 6951, 2646, 462, 36, 1]),
+    (10, [0, 1, 511, 9330, 34105, 42525, 22827, 5880, 750, 45, 1]),
+])
+def test_triangle_inexact(n, expected):
+    """Test full triangle of values for 0 <= n <= 10
+
+    Values taken from Wikipedia
+    https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind
+    """
+    assert_array_equal(stirling2(n, np.arange(0, n + 1), exact=False), expected)
+
+
+@pytest.mark.parametrize('n', [101, 199, 401, 797, 1601, 3217])
+@pytest.mark.parametrize('k', [19, 41, 59, 79, 101])
+def test_modulus(n, k):
     # uses theorem 2.1 from: http://www.oyeat.com/papers/stirling_final.pdf
     assert stirling2(n, k) % 2 == comb(n - (k//2) - 1, n - k) % 2

--- a/scipy/special/tests/test_stirling.py
+++ b/scipy/special/tests/test_stirling.py
@@ -63,7 +63,7 @@ def test_triangle_exact(n, k, expected):
     (10, [0, 1, 511, 9330, 34105, 42525, 22827, 5880, 750, 45, 1]),
 ])
 def test_triangle_inexact(n, expected):
-    """Test full triangle of values for 0 <= n <= 10
+    """Test triangle of values for 0 <= n <= 10 and 0 <= k <= n
 
     Values taken from Wikipedia
     https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind


### PR DESCRIPTION
This PR makes stirling2 follow a similar api to `scipy.special.comb`. It now has a keyword argument `exact`. When True, it uses exact integer arithmetic, but only accepts scalar integer arguments, not arrays. It first tries to use the ufunc based on `stirling2` in `cephes/stirling.c`. If overflow occurs, it tries again with a pure python implementation.  This ufunc has been renamed to `_stirling2` and is now private.

This PR also adds`stirling2_inexact` to `cephes/stirling.c` and a private ufunc based on it. This is used when `exact=False`. So far it just uses `stirling2` from `stirling.c` and casts to double if no overflow, otherwise when overflow it returns `nan`. This is just a placeholder. The plan is to use the uniformly valid asymptotic approximation found on [Wikipedia](https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind#Asymptotic_approximation) which was developed by [Nico Temme](https://onlinelibrary.wiley.com/doi/abs/10.1002/sapm1993893233). 

There is also a new test for the `exact=False` case and `test_modulus` has been given new test cases. I love the idea of `test_modulus`, but the small values previously tested could just as easily be tested exactly based on a reference table. I think this test is better as a sanity check that the function is working for large Stirling numbers.
