### PR TITLE
Filter out irrelevant alerts from sarif

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,11 +3,3 @@ name: "SciPy CodeQL config"
 queries:
     - uses: ./.github/codeql-queries/scipy-code-scanning.qls
     - uses: ./.github/codeql-queries/scipy-c-cpp-queries
-
-paths-ignore:
-  - "dist/**"
-  - "build/**"
-  - "**/*.md"
-  - "**/*.txt"
-  - "tools/**"
-  - "subprojects/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -109,3 +109,30 @@ jobs:
       uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
       with:
         category: "/language:${{matrix.language}}"
+        output: sarif-results
+        upload: failure-only
+
+    - name: filter-sarif
+      uses: advanced-security/filter-sarif@2da736ff05ef065cb2894ac6892e47b5eac2c3c0 # v1.1
+      with:
+        patterns: |
+          - dist/**
+          - "build/**
+          - **/*.md
+          - **/*.txt
+          - tools/**
+          - subprojects/**
+        input: sarif-results/cpp.sarif
+        output: sarif-results/cpp.sarif
+
+    - name: Upload SARIF
+      uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+      with:
+        sarif_file: sarif-results/cpp.sarif
+
+    - name: Upload loc as a Build Artifact
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: sarif-results
+        path: sarif-results
+        retention-days: 1


### PR DESCRIPTION
After consulting with the code scanning team, it turns out that when using `autobuild` or `manual` for a statically typed language (like C++) paths-ignore is ignored: https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#specifying-directories-to-scan. Note the "When codebases are analyzed without building the code".

Either we'll need to make sure that the code we're not interested in doesn't get build, or we need to do some alert filtering. For example with https://github.com/advanced-security/filter-sarif or https://github.com/advanced-security/dismiss-alerts.